### PR TITLE
Add assertion that version can't be empty

### DIFF
--- a/GSVersionComparator/GSComparableVersion.m
+++ b/GSVersionComparator/GSComparableVersion.m
@@ -36,6 +36,7 @@
 @implementation GSComparableVersion
 
 - (id)initWithVersion:(NSString *)version {
+    NSAssert(version.length != 0, @"Version string cannot be empty");
     self = [super init];
     if (self) {
         self.items = [[GSListItem alloc] init];

--- a/Tests/Test Cases/GSVersionComparatorTests.m
+++ b/Tests/Test Cases/GSVersionComparatorTests.m
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTestCase.h>
 #import "GSComparableVersion.h"
+#import "NSString+GSVersionComparator.h"
 
 @interface GSComparableVersionTest : XCTestCase
 @property (nonatomic, strong) NSArray *versionsQualifier;
@@ -58,6 +59,10 @@
 
     XCTAssertTrue([c1 compare:c2] < 0, @"expected %@ < %@", c1, c2);
     XCTAssertTrue([c2 compare:c1] > 0, @"expected %@ > %@", c2, c1);
+}
+
+- (void)testVersionConstruction {
+    XCTAssertThrowsSpecificNamed(@"".gs_comparableVersion, NSException, NSInternalInconsistencyException);
 }
 
 - (void)testVersionsQualifier {


### PR DESCRIPTION
Without this change, accidentally passing an empty string causes a less obvious crash to occur.  Comment out the assertion to see it.

If you accept this change, it would be great if you could push another release to CocoaPods, so I can update my project.

Thanks!
